### PR TITLE
Ajout d'une option pour afficher un clavier aléatoire

### DIFF
--- a/core/class/digiaction.class.php
+++ b/core/class/digiaction.class.php
@@ -495,6 +495,7 @@ class digiaction extends eqLogic {
       $replace['#modeAvailable#'] = $this->getAvailableModeHTML();
       $replace['#currentMode#'] = $this->getCmd(null, 'currentMode')->execCmd();
       // $replace['#message#'] = $this->getCmd(null, 'digimessage')->execCmd();
+      $replace['#randomkeys#'] = $this->getConfiguration('randomkeys', 0);
 
       return $this->postToHtml($_version, template_replace($replace, getTemplate('core', $version, 'digiaction', 'digiaction')));
    }

--- a/core/template/dashboard/digiaction.html
+++ b/core/template/dashboard/digiaction.html
@@ -46,31 +46,6 @@
     <div class="digiActionHideDefault digiactionMainPanel digiactionPanelKeyboard" data-randomkeys="#randomkeys#">
         <ul class="digiActionKeyPressed"></ul>
         <ul class="digiactionPanel digiActionCircle">
-            <div>
-                <li class="digiKeyboard">1</li>
-                <li class="digiKeyboard">2</li>
-                <li class="digiKeyboard">3</li>
-            </div>
-            <div>
-                <li class="digiKeyboard">4</li>
-                <li class="digiKeyboard">5</li>
-                <li class="digiKeyboard">6</li>
-            </div>
-            <div>
-                <li class="digiKeyboard">7</li>
-                <li class="digiKeyboard">8</li>
-                <li class="digiKeyboard">9</li>
-            </div>
-            <div>
-                <li class="digiKeyboard">A</li>
-                <li class="digiKeyboard">0</li>
-                <li class="digiKeyboard">B</li>
-            </div>
-            <div>
-                <li class="digiFunction digiFunctionValidate digiActionBgGreen">V</li>
-                <li class="digiReset digiActionBgYellow">RAZ</li>
-                <li class="digiFunction digiFunctionCancel digiActionBgRed">A</li>
-            </div>
         </ul>
     </div>
 

--- a/core/template/dashboard/digiaction.html
+++ b/core/template/dashboard/digiaction.html
@@ -43,7 +43,7 @@
             </div>
         </ul>
     </div>
-    <div class="digiActionHideDefault digiactionMainPanel digiactionPanelKeyboard ">
+    <div class="digiActionHideDefault digiactionMainPanel digiactionPanelKeyboard" data-randomkeys="#randomkeys#">
         <ul class="digiActionKeyPressed"></ul>
         <ul class="digiactionPanel digiActionCircle">
             <div>

--- a/core/template/dashboard/js/dashboard.digiaction.js
+++ b/core/template/dashboard/js/dashboard.digiaction.js
@@ -18,9 +18,7 @@ $('.digiaction').off('click', '.digiActionMode').on('click', '.digiActionMode', 
 **/
 
 function showDigit(_eqId, _cmdId, _timer) {
-  if ($('.digiaction[data-eqlogic_id=' + _eqId + '] .digiactionPanelKeyboard[data-randomkeys="1"]').length) {
-    shufflePanelKeyboard(_eqId);
-  }
+  makePanelKeyboard($('.digiaction[data-eqlogic_id=' + _eqId + '] .digiactionPanelKeyboard'));
   showOnly($('.digiaction[data-eqlogic_id=' + _eqId + ']'), '.digiactionPanelKeyboard');
 
   $('.digiaction[data-eqlogic_id=' + _eqId + ']').find('.digiFunctionValidate').attr('digi-cmdId', _cmdId)
@@ -214,17 +212,20 @@ function countDown(time, update, complete) {
   }, 100); // the smaller this number, the more accurate the timer will be
 }
 
-function shuffle(array) {
-  for (let i = array.length - 1; i > 0; i--) {
-    let j = Math.floor(Math.random() * (i + 1));
-    [array[i], array[j]] = [array[j], array[i]];
+function shuffle(_arr) {
+  for (let ii = _arr.length - 1; ii > 0; ii--) {
+    let jj = Math.floor(Math.random() * (ii + 1));
+    [_arr[ii], _arr[jj]] = [_arr[jj], _arr[ii]];
   }
-  return array;
+  return _arr;
 }
 
-function shufflePanelKeyboard(_eqId) {
+function makePanelKeyboard(_digiPanelKeyboard) {
   let html = '';
-  let arr = shuffle([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  let arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  if (_digiPanelKeyboard.attr('data-randomkeys') == 1) {
+    arr = shuffle(arr);
+  }
   for (let ii = 0; ii < 3; ii++) {
     html += '<div>';
     for (let jj = 0; jj < 3; jj++) {
@@ -243,7 +244,7 @@ function shufflePanelKeyboard(_eqId) {
   html += '<li class="digiFunction digiFunctionCancel digiActionBgRed">A</li>';
   html += '</div>';
                 
-  $('.digiaction[data-eqlogic_id=' + _eqId + '] .digiactionPanelKeyboard .digiactionPanel').html(html);
+  _digiPanelKeyboard.find('.digiactionPanel').html(html);
 }
 
 if (typeof jeedom.cmd.addUpdateFunction !== 'function') {

--- a/core/template/dashboard/js/dashboard.digiaction.js
+++ b/core/template/dashboard/js/dashboard.digiaction.js
@@ -222,20 +222,20 @@ function shuffle(_arr) {
 
 function makePanelKeyboard(_digiPanelKeyboard) {
   let html = '';
-  let arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  let arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
   if (_digiPanelKeyboard.attr('data-randomkeys') == 1) {
     arr = shuffle(arr);
   }
   for (let ii = 0; ii < 3; ii++) {
     html += '<div>';
     for (let jj = 0; jj < 3; jj++) {
-      html += '<li class="digiKeyboard">'+arr[ii*3+jj]+'</li>';
+      html += '<li class="digiKeyboard">' + arr[ii * 3 + jj] + '</li>';
     }
     html += '</div>';
   }
   html += '<div>';
   html += '<li class="digiKeyboard">A</li>';
-  html += '<li class="digiKeyboard">'+arr[arr.length - 1]+'</li>';
+  html += '<li class="digiKeyboard">' + arr[arr.length - 1] + '</li>';
   html += '<li class="digiKeyboard">B</li>';
   html += '</div>';
   html += '<div>';
@@ -243,7 +243,7 @@ function makePanelKeyboard(_digiPanelKeyboard) {
   html += '<li class="digiReset digiActionBgYellow">RAZ</li>';
   html += '<li class="digiFunction digiFunctionCancel digiActionBgRed">A</li>';
   html += '</div>';
-                
+
   _digiPanelKeyboard.find('.digiactionPanel').html(html);
 }
 

--- a/core/template/dashboard/js/dashboard.digiaction.js
+++ b/core/template/dashboard/js/dashboard.digiaction.js
@@ -18,6 +18,9 @@ $('.digiaction').off('click', '.digiActionMode').on('click', '.digiActionMode', 
 **/
 
 function showDigit(_eqId, _cmdId, _timer) {
+  if ($('.digiaction[data-eqlogic_id=' + _eqId + '] .digiactionPanelKeyboard[data-randomkeys="1"]').length) {
+    shufflePanelKeyboard(_eqId);
+  }
   showOnly($('.digiaction[data-eqlogic_id=' + _eqId + ']'), '.digiactionPanelKeyboard');
 
   $('.digiaction[data-eqlogic_id=' + _eqId + ']').find('.digiFunctionValidate').attr('digi-cmdId', _cmdId)
@@ -209,6 +212,38 @@ function countDown(time, update, complete) {
     }
     else update(Math.floor(now / 1000));
   }, 100); // the smaller this number, the more accurate the timer will be
+}
+
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    let j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+function shufflePanelKeyboard(_eqId) {
+  let html = '';
+  let arr = shuffle([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  for (let ii = 0; ii < 3; ii++) {
+    html += '<div>';
+    for (let jj = 0; jj < 3; jj++) {
+      html += '<li class="digiKeyboard">'+arr[ii*3+jj]+'</li>';
+    }
+    html += '</div>';
+  }
+  html += '<div>';
+  html += '<li class="digiKeyboard">A</li>';
+  html += '<li class="digiKeyboard">'+arr[arr.length - 1]+'</li>';
+  html += '<li class="digiKeyboard">B</li>';
+  html += '</div>';
+  html += '<div>';
+  html += '<li class="digiFunction digiFunctionValidate digiActionBgGreen">V</li>';
+  html += '<li class="digiReset digiActionBgYellow">RAZ</li>';
+  html += '<li class="digiFunction digiFunctionCancel digiActionBgRed">A</li>';
+  html += '</div>';
+                
+  $('.digiaction[data-eqlogic_id=' + _eqId + '] .digiactionPanelKeyboard .digiactionPanel').html(html);
 }
 
 if (typeof jeedom.cmd.addUpdateFunction !== 'function') {

--- a/desktop/php/digiaction.php
+++ b/desktop/php/digiaction.php
@@ -154,6 +154,16 @@ $eqLogics = eqLogic::byType($plugin->getId());
 										<label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="autocall" />Autoriser</label>
 									</div>
 								</div>
+								<div class="form-group">
+									<label class="col-sm-3 control-label">{{Disposition aléatoire des touches numériques du clavier}}
+                                        <sup>
+											<i class="fas fa-question-circle floatright" style="color: var(--al-info-color) !important;" title="Permet d'avoir un clavier différent à chaque utilisation.<br/>Les touches de 0 à 9 seront aléatoirement melangées pour plus de sécurité"></i>
+										</sup>
+</label>
+									<div class="col-sm-7">
+										<label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="randomkeys" />Autoriser</label>
+									</div>
+								</div>
 							</div>
 
 							<div class="col-lg-12">
@@ -253,7 +263,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
 				<div id="div_modes" class="panel-group"></div>
 			</div><!-- /.tabpanel #actiontab-->
 
-			<!-- Onglet des Actions de l'équipement -->
+			<!-- Onglet des Utilisateurs de l'équipement -->
 			<div role="tabpanel" class="tab-pane" id="usertab">
 				<a class="btn btn-success pull-right" id="bt_addUser" style="margin-top: 5px;"><i class="fas fa-plus-circle"></i> {{Ajouter un code utilisateur}}</a><br /><br />
 				<br /><br />

--- a/desktop/php/digiaction.php
+++ b/desktop/php/digiaction.php
@@ -156,10 +156,10 @@ $eqLogics = eqLogic::byType($plugin->getId());
 								</div>
 								<div class="form-group">
 									<label class="col-sm-3 control-label">{{Disposition aléatoire des touches numériques du clavier}}
-                                        <sup>
-											<i class="fas fa-question-circle floatright" style="color: var(--al-info-color) !important;" title="Permet d'avoir un clavier différent à chaque utilisation.<br/>Les touches de 0 à 9 seront aléatoirement melangées pour plus de sécurité"></i>
+										<sup>
+											<i class="fas fa-question-circle floatright" style="color: var(--al-info-color) !important;" title="Permet d'avoir un clavier différent à chaque utilisation.<br/>Les touches de 0 à 9 seront aléatoirement mélangées pour plus de sécurité"></i>
 										</sup>
-</label>
+									</label>
 									<div class="col-sm-7">
 										<label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="randomkeys" />Autoriser</label>
 									</div>


### PR DESCRIPTION
Ajout d'une option sur l'équipement pour avoir un clavier différent à chaque utilisation. Les touches de 0 à 9 seront aléatoirement mélangées.
On peut discuter du choix de mélanger aussi les deux touches supplémentaires 'A' et 'B'...